### PR TITLE
Added first version of a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # About Stockholm React JS
+
+Stockholm React JS is a community of people in Stockholm interested in the web framework React.
+
+This repository is only here to act as a presentation of the group on GitHub, read on below and we will try to guide you to where you want to go.
+
+## Let us guide you right
+
+We are still in the process of setting up our online community and things like a website are still missing. Feel free to check back here later, or open an issue if there is something specific you are missing from the list!
+
+**I am interested in attending an event**
+
+Check out our group on [Meetup](https://www.meetup.com/Stockholm-ReactJS-Meetup/) to see what events we have planned.
+
+**I have an idea for an event**
+
+Check out our [meetups-repository](https://github.com/stockholm-react-js/meetups) here on GitHub.
+
+**I want to help out with an event, or is interested in hosting one**
+
+Check out our [meetups-repository](https://github.com/stockholm-react-js/meetups) here on GitHub.
+
+**I am interested in helping out with the community itself**
+
+That's great! We try to be as transparent as possible and use GitHub for most things. Browse around in our different repositories and read some issues and pull requests to get a sense for what is going on right now. Feel free to join the discussion anywhere and help out where you see fit.
+
+For more information, visit our [governance-repository](https://github.com/stockholm-react-js/governance) where we keep everything not related specifically to meetups and events.
+
+## Contact us
+
+If you'd like to contact us, feel free to file an issue in an appropriate repository, or send an email to: stockholm-react-js@googlegroups.com


### PR DESCRIPTION
I threw together a first version of a README. I guessed that the purpose of this repository was to provide a clear place to start if you came upon the organisation via GitHub, presenting the community and helping visitors find the right place to continue to.

Missing (among other things):

* A good description of the community
* Link to website
* The topic **I'm interested in speaking at an event**